### PR TITLE
Adding support for openmc.Tally inputs

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -31,7 +31,15 @@ jobs:
 
       - name: install packages for tests
         run: |
-          pip install -r requirements-test.txt 
+          pip install -r requirements-test.txt
+
+      - name: Run examples
+        run: |
+          # python examples/spectra_matplotlib_from_tally.py needs openmc
+          python examples/spectra_matplotlib_from_values.py
+          python examples/spectra_plotly_from_values.py
+          python examples/spectrum_matplotlib_from_values.py
+          python examples/spectrum_plotly_from_values.py
 
       - name: Run test_utils
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,8 @@ dmypy.json
 # output files
 *.png
 *.html
+*.h5
+*.xml
+*.stl
+*.h5m
+*.out

--- a/examples/spectra_matplotlib_from_tally.py
+++ b/examples/spectra_matplotlib_from_tally.py
@@ -1,0 +1,101 @@
+import openmc
+import openmc_dagmc_wrapper as odw
+import openmc_plasma_source as ops
+import openmc_post_processor as opp
+import paramak
+from spectrum_plotter import plot_spectra
+from stl_to_h5m import stl_to_h5m
+
+# This minimal example makes a 3D volume and exports the shape to a stp file
+# A surrounding volume called a graveyard is needed for neutronics simulations
+
+my_shape = paramak.ExtrudeStraightShape(
+    points=[(400, 100), (400, 200), (600, 200), (600, 100)],
+    distance=180,
+)
+
+my_shape.export_stl("steel.stl")
+
+# This script converts the CAD stp files generated into h5m files that can be
+# used in DAGMC enabled codes. One of the key aspects of this is the assignment
+# of materials to the volumes present in the CAD files.
+
+stl_to_h5m(
+    files_with_tags=[
+        ("steel.stl", "mat1"),
+    ],
+    h5m_filename="dagmc.h5m",
+)
+
+
+# makes use of the previously created neutronics geometry (h5m file) and assigns
+# actual materials to the material tags. Sets simulation intensity and specifies
+# the neutronics results to record (know as tallies).
+
+
+# defines a simple DT neutron point source
+my_source = ops.FusionPointSource(coordinate=(0, 0, 0), temperature=20000.0, fuel="DT")
+
+# set the geometry file to use
+geometry = odw.Geometry(
+    h5m_filename="dagmc.h5m",
+)
+
+# sets the material to use
+materials = odw.Materials(
+    h5m_filename="dagmc.h5m", correspondence_dict={"mat1": "eurofer"}
+)
+
+# creates a cell tally for neutron spectra
+tally1 = odw.CellTally(tally_type="neutron_spectra", target="mat1", materials=materials)
+
+tallies = openmc.Tallies([tally1])
+
+settings = odw.FusionSettings()
+settings.batches = 2
+settings.particles = 50000
+
+# assigns a ring source of DT energy neutrons to the source using the
+# openmc_plasma_source package
+settings.source = ops.FusionRingSource(fuel="DT", radius=350)
+
+
+my_model = openmc.Model(
+    materials=materials, geometry=geometry, settings=settings, tallies=tallies
+)
+
+# starts the simulation
+statepoint_file = my_model.run()
+
+# loads up the statepoint file with simulation results
+statepoint = openmc.StatePoint(statepoint_file)
+
+# gets the first tally using its name
+my_tally = statepoint.get_tally(name="mat1_neutron_spectra")
+
+# matplotlib style is the default
+test_plot = plot_spectra(
+    spectra=my_tally,
+    x_label="Energy [MeV]",
+    y_label="Flux [n/cm^2s]",
+    x_scale="linear",
+    y_scale="linear",
+    title="example plot 1",
+    filename="example_spectra_from_tally_matplotlib.png",
+)
+
+test_plot.show()
+
+# plotly style
+test_plot = plot_spectra(
+    spectra=my_tally,
+    x_label="Energy [MeV]",
+    y_label="Flux [n/cm^2s]",
+    x_scale="linear",
+    y_scale="linear",
+    title="example plot 1",
+    plotting_package="plotly",
+    filename="example_spectra_from_tally_plotly.html",
+)
+
+test_plot.show()

--- a/examples/spectra_matplotlib_from_values.py
+++ b/examples/spectra_matplotlib_from_values.py
@@ -5,6 +5,7 @@ x = np.array([1, 2, 3, 4, 5, 6])
 y = np.array([0, 1, 1, 0.5, 0.4, 3])
 y_err = np.array([0.2, 0.1, 0.4, 0.1, 0.1, 0.2])
 
+# matplotlib style is the default
 test_plot = plot_spectra(
     spectra=(x, y, y_err),
     x_label="Energy [MeV]",
@@ -12,9 +13,7 @@ test_plot = plot_spectra(
     x_scale="linear",
     y_scale="linear",
     title="example plot 1",
-    plotting_package="plotly",
-    # filename='example_spectra_plotly.png'  # static image export requires kaleido package
-    filename='example_spectra_plotly.html'
+    filename="example_spectra_matplotlib.png",
 )
 
 test_plot.show()

--- a/examples/spectra_plotly_from_values.py
+++ b/examples/spectra_plotly_from_values.py
@@ -5,7 +5,6 @@ x = np.array([1, 2, 3, 4, 5, 6])
 y = np.array([0, 1, 1, 0.5, 0.4, 3])
 y_err = np.array([0.2, 0.1, 0.4, 0.1, 0.1, 0.2])
 
-# matplotlib style is the default
 test_plot = plot_spectra(
     spectra=(x, y, y_err),
     x_label="Energy [MeV]",
@@ -13,7 +12,9 @@ test_plot = plot_spectra(
     x_scale="linear",
     y_scale="linear",
     title="example plot 1",
-    filename='example_spectra_matplotlib.png'
+    plotting_package="plotly",
+    # filename='example_spectra_plotly.png'  # static image export requires kaleido package
+    filename="example_spectra_plotly.html",
 )
 
 test_plot.show()

--- a/examples/spectrum_matplotlib_from_tally.py
+++ b/examples/spectrum_matplotlib_from_tally.py
@@ -1,0 +1,91 @@
+import openmc
+import openmc_dagmc_wrapper as odw
+import openmc_plasma_source as ops
+import openmc_post_processor as opp
+import paramak
+from spectrum_plotter import plot_spectra, plot_spectrum
+from stl_to_h5m import stl_to_h5m
+
+# This minimal example makes a 3D volume and exports the shape to a stp file
+# A surrounding volume called a graveyard is needed for neutronics simulations
+
+my_shape = paramak.ExtrudeStraightShape(
+    points=[(400, 100), (400, 200), (600, 200), (600, 100)],
+    distance=180,
+)
+
+my_shape.export_stl("steel.stl")
+
+# This script converts the CAD stp files generated into h5m files that can be
+# used in DAGMC enabled codes. One of the key aspects of this is the assignment
+# of materials to the volumes present in the CAD files.
+
+stl_to_h5m(
+    files_with_tags=[
+        ("steel.stl", "mat1"),
+    ],
+    h5m_filename="dagmc.h5m",
+)
+
+
+# makes use of the previously created neutronics geometry (h5m file) and assigns
+# actual materials to the material tags. Sets simulation intensity and specifies
+# the neutronics results to record (know as tallies).
+
+
+# defines a simple DT neutron point source
+my_source = ops.FusionPointSource(coordinate=(0, 0, 0), temperature=20000.0, fuel="DT")
+
+# set the geometry file to use
+geometry = odw.Geometry(
+    h5m_filename="dagmc.h5m",
+)
+
+# sets the material to use
+materials = odw.Materials(
+    h5m_filename="dagmc.h5m", correspondence_dict={"mat1": "eurofer"}
+)
+
+# creates a cell tally for neutron spectra
+tally1 = odw.CellTally(tally_type="neutron_spectra", target="mat1", materials=materials)
+tally2 = odw.CellTally(tally_type="photon_spectra", target="mat1", materials=materials)
+
+tallies = openmc.Tallies([tally1, tally2])
+
+settings = odw.FusionSettings()
+settings.batches = 2
+settings.particles = 50000
+settings.photon_transport = True
+
+# assigns a ring source of DT energy neutrons to the source using the
+# openmc_plasma_source package
+settings.source = ops.FusionRingSource(fuel="DT", radius=350)
+
+
+my_model = openmc.Model(
+    materials=materials, geometry=geometry, settings=settings, tallies=tallies
+)
+
+# starts the simulation
+statepoint_file = my_model.run()
+
+# loads up the statepoint file with simulation results
+statepoint = openmc.StatePoint(statepoint_file)
+
+# gets the first tally using its name
+my_tally_1 = statepoint.get_tally(name="mat1_neutron_spectra")
+my_tally_2 = statepoint.get_tally(name="mat1_photon_spectra")
+
+# matplotlib style is the default
+test_plot = plot_spectrum(
+    spectrum={'neutron spectra': my_tally_1, 'photon spectra':my_tally_2},
+    x_label="Energy [MeV]",
+    y_label="Flux [n/cm^2s]",
+    x_scale="linear",
+    y_scale="linear",
+    title="example plot 1",
+    legend=True,
+    filename="example_spectra_from_tally_plotly.html",
+)
+
+test_plot.show()

--- a/examples/spectrum_matplotlib_from_values.py
+++ b/examples/spectrum_matplotlib_from_values.py
@@ -22,7 +22,7 @@ test_plot = plot_spectrum(
     x_scale="linear",
     y_scale="linear",
     title="example plot 1",
-    filename='example_spectrum_matplotlib.png'
+    filename="example_spectrum_matplotlib.png",
 )
 
 test_plot.show()

--- a/examples/spectrum_plotly_from_values.py
+++ b/examples/spectrum_plotly_from_values.py
@@ -21,9 +21,9 @@ test_plot = plot_spectrum(
     x_scale="linear",
     y_scale="linear",
     title="example plot 1",
-    plotting_package='plotly',
+    plotting_package="plotly",
     # filename='example_spectra_plotly.png'  # static image export requires kaleido package
-    filename='example_spectrum_plotly.html'
+    filename="example_spectrum_plotly.html",
 )
 
 test_plot.show()

--- a/spectrum_plotter/core.py
+++ b/spectrum_plotter/core.py
@@ -9,6 +9,169 @@ from numpy.lib.function_base import trim_zeros
 
 
 def plot_spectrum(
+    spectrum: dict,
+    x_label: Optional[str] = "",
+    y_label: Optional[str] = "",
+    x_scale: Optional[str] = "linear",
+    y_scale: Optional[str] = "linear",
+    title: Optional[str] = "",
+    trim_zeros: bool = True,
+    legend: bool = True,
+    filename: Optional[str] = None,
+    plotting_package="matplotlib",
+):
+
+    dictionary_of_values = {}
+
+    for key, value in spectrum.items():
+
+        if isinstance(value, tuple):
+
+            dictionary_of_values[key] = value
+        else:
+            import openmc
+            tally_df = value.get_pandas_dataframe()
+
+            x = tally_df["energy low [eV]"]
+            y = tally_df["mean"]
+            y_err = tally_df["std. dev."]
+
+            dictionary_of_values[key] = (x, y, y_err)
+
+    figure = plot_spectrum_from_values(
+        spectrum=dictionary_of_values,
+        x_label=x_label,
+        y_label=y_label,
+        x_scale=x_scale,
+        y_scale=y_scale,
+        title=title,
+        trim_zeros=trim_zeros,
+        legend=legend,
+        filename=filename,
+        plotting_package=plotting_package,
+    )
+
+    save_plot(plotting_package=plotting_package, filename=filename, figure=figure)
+
+    return figure
+
+
+def plot_spectra(
+    spectra: Tuple[ndarray, ndarray, ndarray],
+    x_label: Optional[str] = "",
+    y_label: Optional[str] = "",
+    x_scale: Optional[str] = "linear",
+    y_scale: Optional[str] = "linear",
+    title: Optional[str] = "",
+    trim_zeros: bool = True,
+    filename: Optional[str] = None,
+    plotting_package="matplotlib",
+):
+
+    if isinstance(spectra, tuple):
+        plot = plot_spectra_from_values(
+            spectra=spectra,
+            x_label=x_label,
+            y_label=y_label,
+            x_scale=x_scale,
+            y_scale=y_scale,
+            title=title,
+            trim_zeros=trim_zeros,
+            filename=filename,
+            plotting_package=plotting_package,
+        )
+    else:
+        plot = plot_spectra_from_tally(
+            spectra=spectra,
+            x_label=x_label,
+            y_label=y_label,
+            x_scale=x_scale,
+            y_scale=y_scale,
+            title=title,
+            trim_zeros=trim_zeros,
+            filename=filename,
+            plotting_package=plotting_package,
+        )
+    return plot
+
+
+def plot_spectrum_from_tally(
+    spectrum: dict,
+    x_label: Optional[str] = "",
+    y_label: Optional[str] = "",
+    x_scale: Optional[str] = "linear",
+    y_scale: Optional[str] = "linear",
+    title: Optional[str] = "",
+    trim_zeros: bool = True,
+    legend: bool = True,
+    filename: Optional[str] = None,
+    plotting_package="matplotlib",
+):
+    import openmc
+
+    dictionary_of_values = {}
+
+    for key, value in spectrum.items():
+        tally_df = value.get_pandas_dataframe()
+
+        x = tally_df["energy low [eV]"]
+        y = tally_df["mean"]
+        y_err = tally_df["std. dev."]
+
+        dictionary_of_values[key] = (x, y, y_err)
+
+    plot = plot_spectrum_from_values(
+        spectrum=dictionary_of_values,
+        x_label=x_label,
+        y_label=y_label,
+        x_scale=x_scale,
+        y_scale=y_scale,
+        title=title,
+        trim_zeros=trim_zeros,
+        legend=legend,
+        filename=filename,
+        plotting_package=plotting_package,
+    )
+
+    return plot
+
+
+def plot_spectra_from_tally(
+    spectra: Tuple[ndarray, ndarray, ndarray],
+    x_label: Optional[str] = "",
+    y_label: Optional[str] = "",
+    x_scale: Optional[str] = "linear",
+    y_scale: Optional[str] = "linear",
+    title: Optional[str] = "",
+    trim_zeros: bool = True,
+    filename: Optional[str] = None,
+    plotting_package="matplotlib",
+):
+
+    import openmc
+
+    tally_df = spectra.get_pandas_dataframe()
+
+    x = tally_df["energy low [eV]"]
+    y = tally_df["mean"]
+    y_err = tally_df["std. dev."]
+
+    plot = plot_spectra_from_values(
+        spectra=(x, y, y_err),
+        x_label=x_label,
+        y_label=y_label,
+        x_scale=x_scale,
+        y_scale=y_scale,
+        title=title,
+        trim_zeros=trim_zeros,
+        filename=filename,
+        plotting_package=plotting_package,
+    )
+
+    return plot
+
+
+def plot_spectrum_from_values(
     spectrum: Dict[str, Tuple[ndarray, ndarray, ndarray]],
     x_label: Optional[str] = "",
     y_label: Optional[str] = "",
@@ -51,19 +214,19 @@ def plot_spectrum(
     for key, value in spectrum.items():
 
         figure = add_spectra_to_plot(
-            value, trim_zeros, label=key, plotting_package=plotting_package, figure=figure
+            value,
+            trim_zeros,
+            label=key,
+            plotting_package=plotting_package,
+            figure=figure,
         )
 
-    save_plot(
-        plotting_package=plotting_package,
-        filename=filename,
-        figure=figure
-    )
+    save_plot(plotting_package=plotting_package, filename=filename, figure=figure)
 
     return figure
 
 
-def plot_spectra(
+def plot_spectra_from_values(
     spectra: Tuple[ndarray, ndarray, ndarray],
     x_label: Optional[str] = "",
     y_label: Optional[str] = "",
@@ -110,32 +273,31 @@ def plot_spectra(
         figure=figure,
     )
 
-    save_plot(
-        plotting_package=plotting_package,
-        filename=filename,
-        figure=figure
-    )
+    save_plot(plotting_package=plotting_package, filename=filename, figure=figure)
 
     return figure
 
-def save_plot(
-        plotting_package: 'str',
-        filename: 'str',
-        figure
-):
+
+def save_plot(plotting_package: "str", filename: "str", figure):
 
     if filename:
-        if plotting_package ==' matplotlib':
+        if plotting_package == " matplotlib":
             figure.savefig(filename, bbox_inches="tight", dpi=400)
-        elif plotting_package == 'plotly':
-            if Path(filename).suffix == '.html':
+        elif plotting_package == "plotly":
+            if Path(filename).suffix == ".html":
                 figure.write_html(filename)
             else:
                 figure.write_image(filename)
- 
+
 
 def add_axis_title_labels(
-    x_label: str, y_label: str, y_scale: str, x_scale: str, title: str, legend: bool, plotting_package:str
+    x_label: str,
+    y_label: str,
+    y_scale: str,
+    x_scale: str,
+    title: str,
+    legend: bool,
+    plotting_package: str,
 ):
 
     if plotting_package == "matplotlib":
@@ -158,38 +320,33 @@ def add_axis_title_labels(
 
         figure.update_layout(
             title=title,
-            xaxis={
-                "title": x_label,
-                "type": x_scale
-            },
-            yaxis={"title": y_label,
-                "type": y_scale
-            },
+            xaxis={"title": x_label, "type": x_scale},
+            yaxis={"title": y_label, "type": y_scale},
         )
 
-        if x_scale == 'log':
-            not_x_scale = 'lin'
+        if x_scale == "log":
+            not_x_scale = "lin"
         else:
-            not_x_scale = 'log'
+            not_x_scale = "log"
 
-        if y_scale == 'log':
-            not_y_scale = 'lin'
+        if y_scale == "log":
+            not_y_scale = "lin"
         else:
-            not_y_scale = 'log'
+            not_y_scale = "log"
 
         buttons_list = []
         for xscale in [x_scale, not_x_scale]:
             for yscale in [y_scale, not_y_scale]:
                 buttons_list.append(
                     {
-                        'args':[
+                        "args": [
                             {
                                 "xaxis.type": xscale,
                                 "yaxis.type": yscale,
                             }
                         ],
-                        'label':f"{xscale}(x) , {yscale}(y)",
-                        'method':"relayout",                
+                        "label": f"{xscale}(x) , {yscale}(y)",
+                        "method": "relayout",
                     }
                 )
 
@@ -258,20 +415,22 @@ def add_spectra_to_plot(
     elif plotting_package == "plotly":
 
         # options are 'linear', 'spline', 'hv', 'vh', 'hvh', 'vhv'
-        shape = 'vh'
+        shape = "vh"
 
         # adds a line for the upper stanadard deviation bound
         figure.add_trace(
             go.Scatter(
-                mode='lines',
-                x=x, y=y + y_err, line=dict(shape=shape, width=0),
+                mode="lines",
+                x=x,
+                y=y + y_err,
+                line=dict(shape=shape, width=0),
             )
         )
 
         # adds a line for the lower stanadard deviation bound
         figure.add_trace(
             go.Scatter(
-                mode='lines',
+                mode="lines",
                 x=x,
                 # todo process std dev correction
                 y=y - y_err,
@@ -286,7 +445,7 @@ def add_spectra_to_plot(
         # adds a line for the tally result
         figure.add_trace(
             go.Scatter(
-                mode='lines',
+                mode="lines",
                 x=x,
                 y=y,
                 name=label,


### PR DESCRIPTION
openmc tallies can be passed in as the spectra. This opens up options for unit conversions in the future.