### PR TITLE
made more generic

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -26,7 +26,7 @@ jobs:
         pip install black
     - name: Run black
       run: |
-        black spectrum_plotter examples tests
+        black .
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "[skip ci] Apply formatting changes"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # spectrum_plotter
 A Python package for creating standard plots for neutron / photon / particle spectrum
+
+# Installation
+
+```bash
+pip install spectrum_plotter
+```
+
+# Usage
+
+There are two main functions for plotting spectrum:
+
+```plot_spectrum_from_values()``` - allows users to pass in the tally via a dictionary of numpy arrays.
+
+```plot_spectrum_from_tally()``` - allows users to pass in an OpenMC tally and plot the result. OpenMC is therefore required for this approach
+
+
+:point_right: [Examples](https://github.com/fusion-energy/spectrum_plotter/tree/main/examples)


### PR DESCRIPTION
improved method of pep8 formatting

can be duplicated locally
popular formatter (black)
skips CI on new commits