### PR TITLE
changing ploting bins from vh to hv

### DIFF
--- a/spectrum_plotter/core.py
+++ b/spectrum_plotter/core.py
@@ -309,7 +309,7 @@ def add_spectra_to_plot(
     elif plotting_package == "plotly":
 
         # options are 'linear', 'spline', 'hv', 'vh', 'hvh', 'vhv'
-        shape = "vh"
+        shape = "hv"
 
         # adds a line for the upper stanadard deviation bound
         figure.add_trace(


### PR DESCRIPTION
I noticed the last energy bin didn't line up correctly so this PR shifts draws the steps of the histogram with plotly vh instead of hv method (v=vertical, h=horizontal)