### PR TITLE
using docker image that has openmc installed

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -20,7 +20,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: openmc/openmc:latest
+      image: openmc/openmc:v0.12.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
the latest openmc docker image was updated recently and didn't include a python installed openmc

this PR changes the target of the container to version 12.2 of openmc which should work